### PR TITLE
fix(tcp-types): remove wbg-rand from deps

### DIFF
--- a/qubic-tcp-types/Cargo.toml
+++ b/qubic-tcp-types/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 getrandom = { version = "*", features = ["js"] }
 serde = { version = "*", features = ["derive"] }
 rand = { version = "*" }
-wbg-rand = "*"
 qubic-types = { path= "../qubic-types" }
 kangarootwelve = "0.1.2"
 


### PR DESCRIPTION
see: https://github.com/alexcrichton/wbg-rand, it's deprecated and it won't compile with rust v1.77