### PR TITLE
fix error with flatten

### DIFF
--- a/qubic-web3-rs/src/client.rs
+++ b/qubic-web3-rs/src/client.rs
@@ -136,7 +136,7 @@ impl<'a, T> Qu<'a, T> where T: Transport {
             unsafe {
                 message.gamming_nonce.0 = rng.gen();
                 copy_nonoverlapping(message.gamming_nonce.0.as_ptr(), shared_key_and_gamming_nonce.as_mut_ptr().add(4) as *mut u8, 32);
-                let mut kg = KangarooTwelve::hash(&shared_key_and_gamming_nonce.iter().map(|i| i.to_le_bytes()).collect::<Vec<_>>().flatten(), &[]);
+                let mut kg = KangarooTwelve::hash(&shared_key_and_gamming_nonce.iter().flat_map(|i| i.to_le_bytes()).collect::<Vec<_>>(), &[]);
                 let mut gk = [0; 32];
                 kg.squeeze(&mut gk);
                 gamming_key = std::array::from_fn(|i| u64::from_le_bytes(gk[i*8..i*8 + 8].try_into().unwrap()));


### PR DESCRIPTION
fixes error[E0599]: no method named `flatten` found for struct `Vec<[u8; 8]>` in the current scope